### PR TITLE
Fix automatic loading of argon2.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ Prerequisites:
 - emscripten with WebAssembly support ([howto](http://webassembly.org/getting-started/developers-guide/))
 - CMake
 
+`generator.js` will automatically load `docs/dist/argon2.js` if the library is not yet present.
+To avoid an extra network request, you can still include `argon2.js` manually before `generator.js`.
+
+
 ## License
 
 [MIT](https://opensource.org/licenses/MIT)

--- a/generator.js
+++ b/generator.js
@@ -1,15 +1,16 @@
 document.addEventListener('DOMContentLoaded', () => {
   'use strict';
 
-  if (!window.argon2) {
-    console.error('argon2 library not present – ensure <script src="docs/dist/argon2.js"></script> is loaded BEFORE generator.js');
-    return;
-  }
+  const init = () => {
+    if (!window.argon2) {
+      console.error('argon2 library still not loaded');
+      return;
+    }
 
-  const { hash, ArgonType } = window.argon2;
-  const goBtn = document.getElementById('go');
-  const copyBtn = document.getElementById('copy');
-  const outField = document.getElementById('out');
+    const { hash, ArgonType } = window.argon2;
+    const goBtn = document.getElementById('go');
+    const copyBtn = document.getElementById('copy');
+    const outField = document.getElementById('out');
 
   goBtn.addEventListener('click', async () => {
     const pass = document.getElementById('pass').value;
@@ -39,9 +40,20 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  copyBtn.addEventListener('click', () => {
-    navigator.clipboard.writeText(outField.value)
-      .then(() => console.log('Copied to clipboard'))
-      .catch(err => console.error('Copy failed', err));
-  });
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(outField.value)
+        .then(() => console.log('Copied to clipboard'))
+        .catch(err => console.error('Copy failed', err));
+    });
+  };
+
+  if (window.argon2) {
+    init();
+  } else {
+    const script = document.createElement('script');
+    script.src = 'docs/dist/argon2.js';
+    script.onload = init;
+    script.onerror = () => console.error('Failed to load argon2 library');
+    document.head.appendChild(script);
+  }
 });


### PR DESCRIPTION
## Summary
- automatically load `docs/dist/argon2.js` from `generator.js` when missing
- note the new behaviour in the README

## Testing
- `npm install` *(with `PUPPETEER_SKIP_DOWNLOAD=1`)*
- `npm test` *(fails: cannot find `../dist/argon2.js` in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684cb400f6fc8330b786541fc211f987