### PR TITLE
Fix library path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /usr/share/nginx/html
 COPY index.html style.css generator.js verifier.js ./
 
 # Copy compiled Argon2 UMD and WASM from docs/dist
-COPY docs/dist/argon2.js docs/dist/argon2.wasm ./docs/dist/
+COPY docs/dist/argon2.js docs/dist/argon2.wasm docs/dist/argon2-simd.wasm ./docs/dist/
 
 EXPOSE 80
 

--- a/generator.js
+++ b/generator.js
@@ -51,7 +51,7 @@ document.addEventListener('DOMContentLoaded', () => {
     init();
   } else {
     const script = document.createElement('script');
-    script.src = 'docs/dist/argon2.js';
+    script.src = '/docs/dist/argon2.js';
     script.onload = init;
     script.onerror = () => console.error('Failed to load argon2 library');
     document.head.appendChild(script);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
   </div>
 
   <!-- Scripts -->
-  <script src="docs/dist/argon2.js"></script>
+  <script src="/docs/dist/argon2.js"></script>
   <script src="generator.js"></script>
   <script src="verifier.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- ensure argon2.js uses an absolute path in HTML and JS
- include SIMD wasm in Docker image
- newline at EOF

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cbac6918483308e6f27aa8eaf6197