### PR TITLE
Fix argon2 asset paths

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -2,7 +2,7 @@ document.addEventListener('DOMContentLoaded', () => {
   'use strict';
 
   if (window.argon2 && window.argon2.wasmURL === undefined) {
-    window.argon2.wasmURL = '/docs/dist/argon2.wasm';
+    window.argon2.wasmURL = 'docs/dist/argon2.wasm';
   }
 
   const init = () => {
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
     init();
   } else {
     const script = document.createElement('script');
-    script.src = '/docs/dist/argon2.js';
+    script.src = 'docs/dist/argon2.js';
     script.onload = init;
     script.onerror = () => console.error('Failed to load argon2 library');
     document.head.appendChild(script);

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
   </div>
 
   <!-- Scripts -->
-  <script src="/docs/dist/argon2.js"></script>
+  <script src="docs/dist/argon2.js"></script>
   <script src="generator.js"></script>
   <script src="verifier.js"></script>
 </body>

--- a/verifier.js
+++ b/verifier.js
@@ -1,5 +1,5 @@
 if (window.argon2 && window.argon2.wasmURL === undefined) {
-  window.argon2.wasmURL = '/docs/dist/argon2.wasm';
+  window.argon2.wasmURL = 'docs/dist/argon2.wasm';
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- load wasm & JS from `docs/dist` using relative paths
- ensure example HTML uses correct path

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test` *(fails: Cannot find module '../dist/argon2.js')*

------
https://chatgpt.com/codex/tasks/task_e_684cc844f3388330b3c838a0f80de19c