### PR TITLE
Fix ArgonType usage in generator

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -11,7 +11,12 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
-    const { hash, ArgonType } = window.argon2;
+    const { hash } = window.argon2;
+    const ArgonTypeEnum = window.argon2.ArgonType || {
+      Argon2d: 0,
+      Argon2i: 1,
+      Argon2id: 2
+    };
     const goBtn = document.getElementById('go');
     const copyBtn = document.getElementById('copy');
     const outField = document.getElementById('out');
@@ -33,7 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
       time: Number(document.getElementById('time').value) || 1,
       mem: Number(document.getElementById('mem').value) || 8,
       parallelism: Number(document.getElementById('parallelism').value) || 1,
-      type: ArgonType[document.getElementById('type').value]
+      type: ArgonTypeEnum[document.getElementById('type').value]
     };
 
     try {


### PR DESCRIPTION
## Summary
- ensure Argon2 type enum is available even if not exported

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd040990c8330a219fc92c80dab5c